### PR TITLE
Launch ec2 instance through Ansible!

### DIFF
--- a/launch ec2 instance
+++ b/launch ec2 instance
@@ -1,0 +1,36 @@
+## Create key pair
+
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - name: Create key pair
+    ec2_key:
+      name: sample
+      region: us-east-1
+    register: keyout
+
+   - name: print key
+     debug:
+       var: keyout
+
+  - name: save key
+    copy:
+      content: "{{keyout.key.private_key}}"
+      dest: ./sample.pem
+    when: keyout.changed
+
+## Launch EC2 instance through Ansible playbook
+  - name: start an instance
+    amazon.aws.ec2_instance:
+      name: "public-compute-instance"
+      key_name: "sample"
+      vpc_subnet_id: subnet-5ca1ab1e
+      instance_type: t2.micro
+      security_group: default
+      network:
+         assign_public_ip: true
+      image_id: ami-id
+      exact_count: 1
+      region: ec2 instance region
+      tags:
+        Environment: Testing


### PR DESCRIPTION
## EC2 -->

Amazon Elastic Compute Cloud is a part of Amazon.com’s cloud-computing platform, Amazon Web Services, that allows users to rent virtual computers on which to run their own computer applications. 

## Ansible-->

 Ansible is a suite of software tools that enables infrastructure as code. It is open-source and the suite includes software provisioning, configuration management, and application deployment functionality.

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/af5721fc-1361-4841-bc30-c288f628ab82)


## Creating an IAM user
You’ll need an AWS account with an IAM user at minimum to provision EC2 instances. These are made through: AWS Console > IAM >Access management> User > create user , as seen below

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/3406ecd9-bea7-4f3d-8f2f-109ce79b3f19)

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/7d9e2f48-02ce-4ce8-a625-1540a1cb64ef)

Then select attach policy directly as seen below

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/43eef811-ba25-49d1-8bc3-829e9dfc6df9)

## Add AWS Access/Secret to Ansible Vault
Edit pass.yml to include your AWS access key and secret access key,
 

ec2_access_key: 'AAAAAAAAAAAAAABBBBBBBBBBBB'                                      
ec2_secret_key: 'enter secret key which you created in IAM in user'

# amazon.aws.ec2_instance module – Create & manage EC2 instances

## Requirements

python >= 3.6

boto3 >= 1.26.0

botocore >= 1.29.0

## Setup Ansible playbook

ubuntu@:~/aws$ cat test-aws.yml

- hosts: localhost
  gather_facts: False
  tasks:
  - name: Create key pair
    ec2_key:
      name: sample
      region: us-east-1
    register: keyout


   - name: print key
     debug:
       var: keyout


  - name: save key
    copy:
      content: "{{keyout.key.private_key}}"
      dest: ./sample.pem
    when: keyout.changed

  - name: start an instance
    amazon.aws.ec2_instance:
      name: "public-compute-instance"       # choose a name of your instance
      key_name: "sample"
      #vpc_subnet_id: subnet-5ca1ab1e
      instance_type: t2.micro              # Choose instance type
      security_group: default           
      network:
        assign_public_ip: true
      image_id: ami-id                     # provide ami-id
      exact_count: 1                       # you can give instance count based on requirement
      region: us-east-1
      tags:
        Environment: Testing

 ##  Run the following command Ansible to generate EC2 instances
$ ansible-playbook file-name.yml

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/b59416d4-a3ac-4e9f-8fb8-37e55b185441)

## Please verify the key pair in EC2 > Network & security > key pairs as seen below.

![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/4cfc5d79-633d-471f-be50-d38c3ec2d37f)


![image](https://github.com/ShivalingBiradar/Ansible-aws/assets/149060582/3dec01f7-9aee-4c14-b0e3-e46e989a4740)



### Congratulations, you’ve now accessed your provisioned instance! through Ansible












